### PR TITLE
to support swift 6.0

### DIFF
--- a/Sources/AsyncFlow/AsyncFlow.swift
+++ b/Sources/AsyncFlow/AsyncFlow.swift
@@ -82,7 +82,7 @@ public class Flow<SharedParams>: FlowCancellable {
         return .success(self.params)
     }
     
-    public var semaphore = DispatchSemaphore(value: 1)
+//    public var semaphore = DispatchSemaphore(value: 1)
     public func asyncFlow(with configure: FlowConfigure = .default, execute: @escaping (SharedParams, FlowCancellable) async throws -> Void) async -> Flow {
         await _async(with: configure) { [self] in
             try await execute(params, self)
@@ -150,11 +150,11 @@ public class Flow<SharedParams>: FlowCancellable {
                 }
                 
                 let task = Task {
-                    semaphore.wait()
+//                    semaphore.wait()
                     try await execute()
                 }
                 currentTask = task
-                semaphore.signal()
+//                semaphore.signal()
                 switch await task.result {
                 case .success():
                     break

--- a/Tests/AsyncFlowTests/AsyncFlowTests.swift
+++ b/Tests/AsyncFlowTests/AsyncFlowTests.swift
@@ -108,7 +108,7 @@ final class AsyncFlowTests: XCTestCase {
         Task {
             let result = await Flow(BL_GetIPs_Parameters()).asyncFlow(with: .set(timeout: 1, retry: 1)) { params, _ in
                 print("1111")
-                try await Task.sleep(nanoseconds: 1_000_000_000)
+                try await Task.sleep(nanoseconds: 2 * 1_000_000_000)
 //                try! await Task.sleep(nanoseconds: 2 * 1_000_000_000)
 //                try await withCheckedThrowingContinuation { continuation in
 //                    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {


### PR DESCRIPTION
In swift 6.0 - Instance method 'wait' is unavailable from asynchronous contexts; Await a Task handle instead; this is an error in Swift 6